### PR TITLE
Fix to shorten generated .cmd for gamecom via libretro MAME...

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -426,10 +426,12 @@ def generateMAMEConfigs(playersControllers: Controllers, system: Emulator, rom: 
         if system.config.get_bool("artworkcrop"):
             commandLine += [ "-artwork_crop" ]
 
-    # Share plugins & samples with standalone MAME (except TI99)
+    # Share plugins with standalone MAME (except TI99)
     if system.name != "ti99":
         commandLine += [ "-pluginspath", f"/usr/bin/mame/plugins/;{SAVES / 'mame' / 'plugins'}" ]
         commandLine += [ "-homepath" , SAVES / 'mame' / 'plugins' ]
+    # Share samples with standalone MAME (except gamecom and TI99)
+    if system.name not in ['gamecom', 'ti99']:
         commandLine += [ "-samplepath", BIOS / "mame" / "samples" ]
     mkdir_if_not_exists(SAVES / "mame" / "plugins")
     mkdir_if_not_exists(BIOS / "mame" / "samples")


### PR DESCRIPTION
Generated .cmd for gamecom using libretro MAME was too long, resulting in a segfault.  Game.com does not use MAME samples, thus the -samplepath param certainly isn't needed.

Removing that addition in generated .cmds now allows gamecom games to launch via libretro MAME.

Fixes batocera.linux/batocera.linux#14339